### PR TITLE
issue 9 - crashing when cancelling AccessTokenForm without having ent…

### DIFF
--- a/DATCCanvasAPIApp/AccessTokenForm.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.cs
@@ -164,7 +164,8 @@ namespace CanvasAPIApp
         //Closing Form
         private void btnCancel_Click(object sender, EventArgs e)
         {
-            this.Close();
+            this.Close(); //closes this form, but continues in CanvasAPIMainForm
+            
         }//End Closing Form
     }
 }

--- a/DATCCanvasAPIApp/CanvasAPIMainForm.cs
+++ b/DATCCanvasAPIApp/CanvasAPIMainForm.cs
@@ -31,12 +31,6 @@ namespace CanvasAPIApp
                 accessTokenForm.StartPosition = FormStartPosition.CenterScreen;
                 accessTokenForm.ShowDialog();
 
-                //asks for access token until one is provided. User should not be allowed to continue without a token
-                while (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == "")
-                {
-                    MessageBox.Show("You must provide an acess token.");
-                    accessTokenForm.ShowDialog();
-                }
             }
 
 
@@ -87,6 +81,9 @@ namespace CanvasAPIApp
                 tabPageModule.Controls.Add(moduleForm);
                 moduleForm.Visible = true;
 
+            //if access token has not been set, don't load grading queue
+            if ( ! (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == "")) //if default access token
+            {
                 //Load Grading Queue
                 GradingQueue gradingQueue = new GradingQueue();
 
@@ -96,8 +93,8 @@ namespace CanvasAPIApp
                 gradingQueue.Dock = DockStyle.Fill;
                 tabPageGradingQueue.Controls.Add(gradingQueue);
                 gradingQueue.Visible = true;
-            
 
+            }
 
 
             //if there is no user saved add the user, this is to update the user name in the properties if the user already saved the canvas access
@@ -134,6 +131,21 @@ namespace CanvasAPIApp
             accessTokenForm.StartPosition = FormStartPosition.CenterScreen;
             accessTokenForm.ShowDialog();
             Cursor.Current = Cursors.Default;
+
+            //loads grading queue if access token is set
+            if ( ! (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == ""))
+            {
+                //Load Grading Queue
+                GradingQueue gradingQueue = new GradingQueue();
+
+                //tab setup
+                gradingQueue.TopLevel = false;
+                gradingQueue.FormBorderStyle = FormBorderStyle.None;
+                gradingQueue.Dock = DockStyle.Fill;
+                tabPageGradingQueue.Controls.Add(gradingQueue);
+                gradingQueue.Visible = true;
+            }
+
         }
 
         //Open Current Profile form

--- a/DATCCanvasAPIApp/CanvasAPIMainForm.cs
+++ b/DATCCanvasAPIApp/CanvasAPIMainForm.cs
@@ -30,66 +30,77 @@ namespace CanvasAPIApp
                 accessTokenForm.ShowDialog();
             }
             //if there is no user saved add the user, this is to update the user name in the properties if the user already saved the canvas access
-            if(Properties.Settings.Default.AppUserName == "")
+            if (Properties.Settings.Default.AppUserName == "")
             {
                 GeneralAPIGets getProfile = new GeneralAPIGets();
                 Properties.Settings.Default.AppUserName = getProfile.GetProfile("name");
             }
 
-            //Load assignment tab
-            AssignmentForm assignForm = new AssignmentForm("Create Assignement");
-            //tab setup
-            assignForm.TopLevel = false;
-            assignForm.FormBorderStyle = FormBorderStyle.None;
-            assignForm.Dock = DockStyle.Fill;
-            tabPageAssign.Controls.Add(assignForm);
-            assignForm.Visible = true;
+            //only loads the main form if an access token has been provided
+            if (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == "") //acess token has not been set
+            {
+                Application.Exit(); //exits application, because AccessTokenForm was cancelled with no input
 
-            //Load quiz form
-            QuizForm quizForm = new QuizForm("Create Quiz", "Create Quiz");
-            //tab setup
-            quizForm.TopLevel = false;
-            quizForm.FormBorderStyle = FormBorderStyle.None;
-            quizForm.Dock = DockStyle.Fill;
-            tabPageQuiz.Controls.Add(quizForm);
-            quizForm.Visible = true;
+            }else //access token has been set
+            {
 
-            //Load pages form
-            PagesForm pageForm = new PagesForm();
-            //tab setup
-            pageForm.TopLevel = false;
-            pageForm.FormBorderStyle = FormBorderStyle.None;
-            pageForm.Dock = DockStyle.Fill;
-            tabPagePages.Controls.Add(pageForm);
-            pageForm.Visible = true;
+                //Load assignment tab
+                AssignmentForm assignForm = new AssignmentForm("Create Assignement");
+                //tab setup
+                assignForm.TopLevel = false;
+                assignForm.FormBorderStyle = FormBorderStyle.None;
+                assignForm.Dock = DockStyle.Fill;
+                tabPageAssign.Controls.Add(assignForm);
+                assignForm.Visible = true;
 
-            //Load courses form
-            CoursesForm coursesForm = new CoursesForm();
-            //tab setup
-            coursesForm.TopLevel = false;
-            coursesForm.FormBorderStyle = FormBorderStyle.None;
-            coursesForm.Dock = DockStyle.Fill;
-            tabPageCourses.Controls.Add(coursesForm);
-            coursesForm.Visible = true;
+                //Load quiz form
+                QuizForm quizForm = new QuizForm("Create Quiz", "Create Quiz");
+                //tab setup
+                quizForm.TopLevel = false;
+                quizForm.FormBorderStyle = FormBorderStyle.None;
+                quizForm.Dock = DockStyle.Fill;
+                tabPageQuiz.Controls.Add(quizForm);
+                quizForm.Visible = true;
 
-            //Load Module form
-            ModuleForm moduleForm = new ModuleForm();
-            //tab setup
-            moduleForm.TopLevel = false;
-            moduleForm.FormBorderStyle = FormBorderStyle.None;
-            moduleForm.Dock = DockStyle.Fill;
-            tabPageModule.Controls.Add(moduleForm);
-            moduleForm.Visible = true;
+                //Load pages form
+                PagesForm pageForm = new PagesForm();
+                //tab setup
+                pageForm.TopLevel = false;
+                pageForm.FormBorderStyle = FormBorderStyle.None;
+                pageForm.Dock = DockStyle.Fill;
+                tabPagePages.Controls.Add(pageForm);
+                pageForm.Visible = true;
 
-            //Load Grading Queue
-            GradingQueue gradingQueue = new GradingQueue();
+                //Load courses form
+                CoursesForm coursesForm = new CoursesForm();
+                //tab setup
+                coursesForm.TopLevel = false;
+                coursesForm.FormBorderStyle = FormBorderStyle.None;
+                coursesForm.Dock = DockStyle.Fill;
+                tabPageCourses.Controls.Add(coursesForm);
+                coursesForm.Visible = true;
 
-            //tab setup
-            gradingQueue.TopLevel = false;
-            gradingQueue.FormBorderStyle = FormBorderStyle.None;
-            gradingQueue.Dock = DockStyle.Fill;            
-            tabPageGradingQueue.Controls.Add(gradingQueue);
-            gradingQueue.Visible = true;
+                //Load Module form
+                ModuleForm moduleForm = new ModuleForm();
+                //tab setup
+                moduleForm.TopLevel = false;
+                moduleForm.FormBorderStyle = FormBorderStyle.None;
+                moduleForm.Dock = DockStyle.Fill;
+                tabPageModule.Controls.Add(moduleForm);
+                moduleForm.Visible = true;
+
+                //Load Grading Queue
+                GradingQueue gradingQueue = new GradingQueue();
+
+                //tab setup
+                gradingQueue.TopLevel = false;
+                gradingQueue.FormBorderStyle = FormBorderStyle.None;
+                gradingQueue.Dock = DockStyle.Fill;
+                tabPageGradingQueue.Controls.Add(gradingQueue);
+                gradingQueue.Visible = true;
+            
+            }//End form load if
+
 
         }//End Main Form Loading
 

--- a/DATCCanvasAPIApp/CanvasAPIMainForm.cs
+++ b/DATCCanvasAPIApp/CanvasAPIMainForm.cs
@@ -23,26 +23,24 @@ namespace CanvasAPIApp
         //Loading Main form
         private void CanvasAPIMainForm_Load(object sender, EventArgs e)
         {
+           
+
             //If there is no token automaticly open settings
             if (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == "")
             {
                 accessTokenForm.StartPosition = FormStartPosition.CenterScreen;
                 accessTokenForm.ShowDialog();
-            }
-            //if there is no user saved add the user, this is to update the user name in the properties if the user already saved the canvas access
-            if (Properties.Settings.Default.AppUserName == "")
-            {
-                GeneralAPIGets getProfile = new GeneralAPIGets();
-                Properties.Settings.Default.AppUserName = getProfile.GetProfile("name");
+
+                //asks for access token until one is provided. User should not be allowed to continue without a token
+                while (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == "")
+                {
+                    MessageBox.Show("You must provide an acess token.");
+                    accessTokenForm.ShowDialog();
+                }
             }
 
-            //only loads the main form if an access token has been provided
-            if (Properties.Settings.Default.CurrentAccessToken == "No Access Token" || Properties.Settings.Default.CurrentAccessToken == "") //acess token has not been set
-            {
-                Application.Exit(); //exits application, because AccessTokenForm was cancelled with no input
 
-            }else //access token has been set
-            {
+            //loads main form components
 
                 //Load assignment tab
                 AssignmentForm assignForm = new AssignmentForm("Create Assignement");
@@ -99,7 +97,18 @@ namespace CanvasAPIApp
                 tabPageGradingQueue.Controls.Add(gradingQueue);
                 gradingQueue.Visible = true;
             
-            }//End form load if
+
+
+
+            //if there is no user saved add the user, this is to update the user name in the properties if the user already saved the canvas access
+            if (Properties.Settings.Default.AppUserName == "")
+            {
+                GeneralAPIGets getProfile = new GeneralAPIGets();
+                Properties.Settings.Default.AppUserName = getProfile.GetProfile("name");
+            }
+
+            //only loads the main form if an access token has been provided
+            
 
 
         }//End Main Form Loading


### PR DESCRIPTION
…ered an access token.

I added a default check in the main form after the AccessTokenForm dialog. This must be done in the main form (not the AccessTokenForm) because the main form creates the AccessTokenForm dialog and then continues.

This still does not address the possibility that a user has entered an incorrect access token (which may be a brand new issue), it only checks that a user has closed the AccessTokenForm without having entered a token at all.