### PR TITLE
Grading queue reloading

### DIFF
--- a/DATCCanvasAPIApp/Course.cs
+++ b/DATCCanvasAPIApp/Course.cs
@@ -2,7 +2,7 @@
 {
     public partial class GradingQueue
     {
-        class Course
+        public class Course
         {
             public string CourseID { get; set; }
             public string CourseName { get; set; }

--- a/DATCCanvasAPIApp/GradingQueue.Designer.cs
+++ b/DATCCanvasAPIApp/GradingQueue.Designer.cs
@@ -46,6 +46,7 @@
             this.courseFilterTxt = new System.Windows.Forms.TextBox();
             this.courseFilterLbl = new System.Windows.Forms.Label();
             this.btnPrioritySettings = new System.Windows.Forms.Button();
+            this.btnLoadCourses = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.gradingDataGrid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudSeconds)).BeginInit();
             this.SuspendLayout();
@@ -153,7 +154,7 @@
             this.btnRefreshQueue.Name = "btnRefreshQueue";
             this.btnRefreshQueue.Size = new System.Drawing.Size(152, 23);
             this.btnRefreshQueue.TabIndex = 1;
-            this.btnRefreshQueue.Text = "Refresh Grading Queue";
+            this.btnRefreshQueue.Text = "Refresh Assignments";
             this.btnRefreshQueue.UseVisualStyleBackColor = false;
             this.btnRefreshQueue.Click += new System.EventHandler(this.btnRefreshQueue_Click);
             // 
@@ -200,7 +201,7 @@
             // lblMessageBox
             // 
             this.lblMessageBox.AutoSize = true;
-            this.lblMessageBox.Location = new System.Drawing.Point(174, 8);
+            this.lblMessageBox.Location = new System.Drawing.Point(167, 8);
             this.lblMessageBox.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.lblMessageBox.Name = "lblMessageBox";
             this.lblMessageBox.Size = new System.Drawing.Size(0, 13);
@@ -209,7 +210,7 @@
             // courseFilterTxt
             // 
             this.courseFilterTxt.Enabled = false;
-            this.courseFilterTxt.Location = new System.Drawing.Point(245, 27);
+            this.courseFilterTxt.Location = new System.Drawing.Point(280, 27);
             this.courseFilterTxt.Name = "courseFilterTxt";
             this.courseFilterTxt.Size = new System.Drawing.Size(100, 20);
             this.courseFilterTxt.TabIndex = 5;
@@ -218,11 +219,11 @@
             // courseFilterLbl
             // 
             this.courseFilterLbl.AutoSize = true;
-            this.courseFilterLbl.Location = new System.Drawing.Point(174, 30);
+            this.courseFilterLbl.Location = new System.Drawing.Point(211, 31);
             this.courseFilterLbl.Name = "courseFilterLbl";
-            this.courseFilterLbl.Size = new System.Drawing.Size(65, 13);
+            this.courseFilterLbl.Size = new System.Drawing.Size(70, 13);
             this.courseFilterLbl.TabIndex = 6;
-            this.courseFilterLbl.Text = "Filter Course";
+            this.courseFilterLbl.Text = "Filter Courses";
             // 
             // btnPrioritySettings
             // 
@@ -237,19 +238,32 @@
             this.btnPrioritySettings.UseVisualStyleBackColor = false;
             this.btnPrioritySettings.Click += new System.EventHandler(this.btnPrioritySettings_Click);
             // 
+            // btnLoadCourses
+            // 
+            this.btnLoadCourses.BackColor = System.Drawing.SystemColors.ButtonHighlight;
+            this.btnLoadCourses.Location = new System.Drawing.Point(285, 5);
+            this.btnLoadCourses.Margin = new System.Windows.Forms.Padding(2);
+            this.btnLoadCourses.Name = "btnLoadCourses";
+            this.btnLoadCourses.Size = new System.Drawing.Size(95, 20);
+            this.btnLoadCourses.TabIndex = 8;
+            this.btnLoadCourses.Text = "Refresh courses";
+            this.btnLoadCourses.UseVisualStyleBackColor = false;
+            this.btnLoadCourses.Click += new System.EventHandler(this.btnLoadCourses_Click);
+            // 
             // GradingQueue
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(844, 526);
+            this.Controls.Add(this.btnLoadCourses);
             this.Controls.Add(this.btnPrioritySettings);
-            this.Controls.Add(this.courseFilterLbl);
             this.Controls.Add(this.courseFilterTxt);
             this.Controls.Add(this.lblMessageBox);
             this.Controls.Add(this.nudSeconds);
             this.Controls.Add(this.cbxAutoRefresh);
             this.Controls.Add(this.btnRefreshQueue);
             this.Controls.Add(this.gradingDataGrid);
+            this.Controls.Add(this.courseFilterLbl);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "GradingQueue";
             this.Text = "GradingQueue";
@@ -280,5 +294,6 @@
         private System.Windows.Forms.DataGridViewLinkColumn Speedgrader_url;
         private System.Windows.Forms.DataGridViewTextBoxColumn grades_url;
         private System.Windows.Forms.Button btnPrioritySettings;
+        private System.Windows.Forms.Button btnLoadCourses;
     }
 }

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -20,6 +20,7 @@ namespace CanvasAPIApp
         MongoClient mongoClient;
         IMongoDatabase mongoDatabase;
 
+        public static List<Course> CourseList { get; set; } = new List<Course>();
 
         public static PrioritySettings prioritySettings = new PrioritySettings();
         public static int defaultPriority { get; set; }
@@ -66,6 +67,15 @@ namespace CanvasAPIApp
             prioritySettings = new PrioritySettings();
             defaultPriority = Properties.Settings.Default.DefaultPriority;
 
+             
+        }
+
+        private async void btnLoadCourses_Click(object sender, EventArgs e)
+        {
+            //forces a reload of courses then continues to load assignments
+            lblMessageBox.Text = "Getting Courses";
+            CourseList = await populateListOfCourses();
+            await RefreshQueue();
         }
 
         private async Task RefreshQueue()
@@ -73,17 +83,23 @@ namespace CanvasAPIApp
             //reload the data
             btnRefreshQueue.Enabled = false;
             lblMessageBox.Text = "Getting Courses";
-            var courseList = await populateListOfCourses();
+
+            //gets courses if they aren't already set
+            if (CourseList.Count == 0)
+            {
+                CourseList = await populateListOfCourses();
+            }
+
             lblMessageBox.Text = "Getting Reserved Assignments";
             List<ReservedAssignment> gradingReservedList = new List<ReservedAssignment>();
             if (connectedToMongoDB == true)
             {
                 gradingReservedList = await PopulateListOfReservedAssignments();
             }
-            if (courseList.Count > 0)
+            if (CourseList.Count > 0)
             {
                 lblMessageBox.Text = "Loading Assignments";
-                ungradedAssignmentList = await populateGradingEventHistory(courseList, gradingReservedList);
+                ungradedAssignmentList = await populateGradingEventHistory(CourseList, gradingReservedList);
                 LoadDataGridView(courseFilter(ungradedAssignmentList, courseFilterTxt.Text));
             }
             else
@@ -102,6 +118,9 @@ namespace CanvasAPIApp
                     mongoCollection.DeleteOne(filter);
                 }
             }
+
+            // using this method as hook to enable courseFilterTxt
+            enableCourseFilter();
 
         }
 
@@ -156,8 +175,7 @@ namespace CanvasAPIApp
         {
             await RefreshQueue();
 
-            // using this method as hook to enable courseFilterTxt
-            enableCourseFilter();
+            
         }
 
         // return priority based on assignment name
@@ -540,5 +558,6 @@ namespace CanvasAPIApp
             }
         }
 
+        
     }
 }

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -146,6 +146,7 @@ namespace CanvasAPIApp
             {
                 foreach (Assignment assignment in assignmentList)
                 {
+                    // here is the bug 
                     if (assignment.priority < 4 && sortByPriority == false)
                         sortByPriority = true;
 

--- a/DATCCanvasAPIApp/GradingQueue.resx
+++ b/DATCCanvasAPIApp/GradingQueue.resx
@@ -141,6 +141,30 @@
   <metadata name="grades_url.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="reserved.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Priority.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="CourseNumber.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="AssignmentNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Submit_at.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Workflow_state.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="Speedgrader_url.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="grades_url.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="timerRefreshQueue.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>


### PR DESCRIPTION
The grading queue should now only need to load the courses the first time, then it can draw from the existing list. If there is a change to courses or enrollment (or for some other reason the user needs to refresh all the courses manually), there is now a button for this too.

I think the label that says "Loading courses" / "Loading assignments" will make it clear to the user what all is happening.