### PR TITLE
Url crash fix

### DIFF
--- a/DATCCanvasAPIApp/AccessTokenForm.Designer.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.Designer.cs
@@ -44,9 +44,9 @@
             // 
             // saveAccessToken
             // 
-            this.saveAccessToken.Location = new System.Drawing.Point(18, 242);
+            this.saveAccessToken.Location = new System.Drawing.Point(22, 241);
             this.saveAccessToken.Name = "saveAccessToken";
-            this.saveAccessToken.Size = new System.Drawing.Size(136, 32);
+            this.saveAccessToken.Size = new System.Drawing.Size(136, 34);
             this.saveAccessToken.TabIndex = 1;
             this.saveAccessToken.Text = "Save Access Token";
             this.saveAccessToken.UseVisualStyleBackColor = true;
@@ -63,7 +63,7 @@
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(15, 182);
+            this.label2.Location = new System.Drawing.Point(18, 175);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(109, 20);
             this.label2.TabIndex = 4;
@@ -140,7 +140,7 @@
             // 
             this.lnkGetAccessTokenLink.AutoSize = true;
             this.lnkGetAccessTokenLink.Enabled = false;
-            this.lnkGetAccessTokenLink.Location = new System.Drawing.Point(127, 187);
+            this.lnkGetAccessTokenLink.Location = new System.Drawing.Point(23, 195);
             this.lnkGetAccessTokenLink.Name = "lnkGetAccessTokenLink";
             this.lnkGetAccessTokenLink.Size = new System.Drawing.Size(0, 13);
             this.lnkGetAccessTokenLink.TabIndex = 12;
@@ -150,7 +150,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(617, 295);
+            this.ClientSize = new System.Drawing.Size(600, 295);
             this.Controls.Add(this.lnkGetAccessTokenLink);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lbxCurrentUser);

--- a/DATCCanvasAPIApp/AccessTokenForm.Designer.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.Designer.cs
@@ -39,14 +39,14 @@
             this.lblCurrentUser = new System.Windows.Forms.Label();
             this.lbxCurrentUser = new System.Windows.Forms.Label();
             this.label1 = new System.Windows.Forms.Label();
+            this.lnkGetAccessTokenLink = new System.Windows.Forms.LinkLabel();
             this.SuspendLayout();
             // 
             // saveAccessToken
             // 
-            this.saveAccessToken.Location = new System.Drawing.Point(37, 466);
-            this.saveAccessToken.Margin = new System.Windows.Forms.Padding(6);
+            this.saveAccessToken.Location = new System.Drawing.Point(18, 242);
             this.saveAccessToken.Name = "saveAccessToken";
-            this.saveAccessToken.Size = new System.Drawing.Size(272, 62);
+            this.saveAccessToken.Size = new System.Drawing.Size(136, 32);
             this.saveAccessToken.TabIndex = 1;
             this.saveAccessToken.Text = "Save Access Token";
             this.saveAccessToken.UseVisualStyleBackColor = true;
@@ -54,20 +54,18 @@
             // 
             // txbCurrentAccessToken
             // 
-            this.txbCurrentAccessToken.Location = new System.Drawing.Point(37, 407);
-            this.txbCurrentAccessToken.Margin = new System.Windows.Forms.Padding(6);
+            this.txbCurrentAccessToken.Location = new System.Drawing.Point(18, 212);
             this.txbCurrentAccessToken.Name = "txbCurrentAccessToken";
-            this.txbCurrentAccessToken.Size = new System.Drawing.Size(1060, 31);
+            this.txbCurrentAccessToken.Size = new System.Drawing.Size(532, 20);
             this.txbCurrentAccessToken.TabIndex = 2;
             // 
             // label2
             // 
             this.label2.AutoSize = true;
             this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(30, 350);
-            this.label2.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label2.Location = new System.Drawing.Point(15, 182);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(218, 37);
+            this.label2.Size = new System.Drawing.Size(109, 20);
             this.label2.TabIndex = 4;
             this.label2.Text = "Access Token";
             // 
@@ -75,27 +73,24 @@
             // 
             this.label3.AutoSize = true;
             this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(30, 124);
-            this.label3.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label3.Location = new System.Drawing.Point(15, 64);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(292, 37);
+            this.label3.Size = new System.Drawing.Size(148, 20);
             this.label3.TabIndex = 5;
             this.label3.Text = "Instructure Website";
             // 
             // txbWebsite
             // 
-            this.txbWebsite.Location = new System.Drawing.Point(37, 198);
-            this.txbWebsite.Margin = new System.Windows.Forms.Padding(6);
+            this.txbWebsite.Location = new System.Drawing.Point(18, 103);
             this.txbWebsite.Name = "txbWebsite";
-            this.txbWebsite.Size = new System.Drawing.Size(1060, 31);
+            this.txbWebsite.Size = new System.Drawing.Size(532, 20);
             this.txbWebsite.TabIndex = 6;
             // 
             // btnSaveWebsite
             // 
-            this.btnSaveWebsite.Location = new System.Drawing.Point(37, 241);
-            this.btnSaveWebsite.Margin = new System.Windows.Forms.Padding(6);
+            this.btnSaveWebsite.Location = new System.Drawing.Point(18, 125);
             this.btnSaveWebsite.Name = "btnSaveWebsite";
-            this.btnSaveWebsite.Size = new System.Drawing.Size(272, 65);
+            this.btnSaveWebsite.Size = new System.Drawing.Size(136, 34);
             this.btnSaveWebsite.TabIndex = 7;
             this.btnSaveWebsite.Text = "Save Website";
             this.btnSaveWebsite.UseVisualStyleBackColor = true;
@@ -103,10 +98,9 @@
             // 
             // btnCancel
             // 
-            this.btnCancel.Location = new System.Drawing.Point(369, 463);
-            this.btnCancel.Margin = new System.Windows.Forms.Padding(6);
+            this.btnCancel.Location = new System.Drawing.Point(184, 241);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(322, 65);
+            this.btnCancel.Size = new System.Drawing.Size(161, 34);
             this.btnCancel.TabIndex = 8;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -116,10 +110,9 @@
             // 
             this.lblCurrentUser.AutoSize = true;
             this.lblCurrentUser.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lblCurrentUser.Location = new System.Drawing.Point(32, 58);
-            this.lblCurrentUser.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lblCurrentUser.Location = new System.Drawing.Point(16, 30);
             this.lblCurrentUser.Name = "lblCurrentUser";
-            this.lblCurrentUser.Size = new System.Drawing.Size(209, 37);
+            this.lblCurrentUser.Size = new System.Drawing.Size(104, 20);
             this.lblCurrentUser.TabIndex = 9;
             this.lblCurrentUser.Text = "Current User:";
             // 
@@ -127,10 +120,9 @@
             // 
             this.lbxCurrentUser.AutoSize = true;
             this.lbxCurrentUser.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.lbxCurrentUser.Location = new System.Drawing.Point(253, 58);
-            this.lbxCurrentUser.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.lbxCurrentUser.Location = new System.Drawing.Point(126, 30);
             this.lbxCurrentUser.Name = "lbxCurrentUser";
-            this.lbxCurrentUser.Size = new System.Drawing.Size(251, 37);
+            this.lbxCurrentUser.Size = new System.Drawing.Size(125, 20);
             this.lbxCurrentUser.TabIndex = 11;
             this.lbxCurrentUser.Text = "No User Loaded";
             // 
@@ -138,18 +130,28 @@
             // 
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F);
-            this.label1.Location = new System.Drawing.Point(31, 161);
-            this.label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
+            this.label1.Location = new System.Drawing.Point(16, 84);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(583, 31);
+            this.label1.Size = new System.Drawing.Size(304, 17);
             this.label1.TabIndex = 10;
             this.label1.Text = "(example: https://your_domain.instructure.com)";
             // 
+            // lnkGetAccessTokenLink
+            // 
+            this.lnkGetAccessTokenLink.AutoSize = true;
+            this.lnkGetAccessTokenLink.Enabled = false;
+            this.lnkGetAccessTokenLink.Location = new System.Drawing.Point(127, 187);
+            this.lnkGetAccessTokenLink.Name = "lnkGetAccessTokenLink";
+            this.lnkGetAccessTokenLink.Size = new System.Drawing.Size(0, 13);
+            this.lnkGetAccessTokenLink.TabIndex = 12;
+            this.lnkGetAccessTokenLink.Click += new System.EventHandler(this.lnkGetAccessTokenLink_Click);
+            // 
             // AccessTokenForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1234, 567);
+            this.ClientSize = new System.Drawing.Size(617, 295);
+            this.Controls.Add(this.lnkGetAccessTokenLink);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.lbxCurrentUser);
             this.Controls.Add(this.lblCurrentUser);
@@ -161,7 +163,6 @@
             this.Controls.Add(this.txbCurrentAccessToken);
             this.Controls.Add(this.saveAccessToken);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(6);
             this.Name = "AccessTokenForm";
             this.Text = "Access Token";
             this.Shown += new System.EventHandler(this.AccessTokenForm_Shown);
@@ -181,5 +182,6 @@
         private System.Windows.Forms.Label lblCurrentUser;
         private System.Windows.Forms.Label lbxCurrentUser;
         private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.LinkLabel lnkGetAccessTokenLink;
     }
 }

--- a/DATCCanvasAPIApp/AccessTokenForm.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.cs
@@ -150,7 +150,6 @@ namespace CanvasAPIApp
         private void btnCancel_Click(object sender, EventArgs e)
         {
             this.Close(); //closes this form, but continues in CanvasAPIMainForm
-            this.Dispose();
 
         }//End Closing Form
 

--- a/DATCCanvasAPIApp/AccessTokenForm.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.cs
@@ -104,7 +104,7 @@ namespace CanvasAPIApp
                 Properties.Settings.Default.Save();
 
                 lnkGetAccessTokenLink.Enabled = true;
-                lnkGetAccessTokenLink.Text = $"Generate access token";
+                lnkGetAccessTokenLink.Text = $"(Generate access token)";
 
             }
             //if HttpWebResponse response = (HttpWebResponse)request.GetResponse(); fails then throw an error
@@ -129,7 +129,7 @@ namespace CanvasAPIApp
             if (Properties.Settings.Default.InstructureSite != "" && Properties.Settings.Default.InstructureSite != "No URL saved")
             {
                 lnkGetAccessTokenLink.Enabled = true;
-                lnkGetAccessTokenLink.Text = $"Generate access token";
+                lnkGetAccessTokenLink.Text = $"(Generate access token)";
             }
 
             string currentAccessToken = Properties.Settings.Default.CurrentAccessToken;

--- a/DATCCanvasAPIApp/AccessTokenForm.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.cs
@@ -89,7 +89,8 @@ namespace CanvasAPIApp
         //Saving Website
         private void btnSaveWebsite_Click(object sender, EventArgs e)
         {
-
+            //wait cursor
+            Cursor.Current = Cursors.WaitCursor;
 
             try
             {
@@ -119,6 +120,8 @@ namespace CanvasAPIApp
 
             btnCancel.Text = "Close";
 
+            Cursor.Current = Cursors.Default;
+
         }//End Saving website
 
         private void PopulateSavedSettings()
@@ -147,6 +150,7 @@ namespace CanvasAPIApp
         private void btnCancel_Click(object sender, EventArgs e)
         {
             this.Close(); //closes this form, but continues in CanvasAPIMainForm
+            this.Dispose();
 
         }//End Closing Form
 

--- a/DATCCanvasAPIApp/AccessTokenForm.cs
+++ b/DATCCanvasAPIApp/AccessTokenForm.cs
@@ -14,7 +14,7 @@ namespace CanvasAPIApp
             InitializeComponent();
         }
 
-        
+
 
         //Saving token
         private void saveAccessToken_Click(object sender, EventArgs e)
@@ -90,35 +90,56 @@ namespace CanvasAPIApp
         private void btnSaveWebsite_Click(object sender, EventArgs e)
         {
 
-            WebRequest webRequest = WebRequest.Create(txbWebsite.Text.ToString());
-            WebResponse webResponse;
+
             try
             {
+                WebRequest webRequest = WebRequest.Create(txbWebsite.Text.ToString());
+                WebResponse webResponse;
+
                 webResponse = webRequest.GetResponse();
                 MessageBox.Show("The site has been saved.", "Success", MessageBoxButtons.OK);
+
+                //Saving Website to settings
+                Properties.Settings.Default.InstructureSite = txbWebsite.Text.ToString();
+                Properties.Settings.Default.Save();
+
+                lnkGetAccessTokenLink.Enabled = true;
+                lnkGetAccessTokenLink.Text = $"Generate access token";
+
             }
             //if HttpWebResponse response = (HttpWebResponse)request.GetResponse(); fails then throw an error
             catch (WebException)
             {
                 MessageBox.Show("Failed to reach site.", "Failed", MessageBoxButtons.OK);
             }
-            //Saving Website to settings
-            Properties.Settings.Default.InstructureSite = txbWebsite.Text.ToString();
-            Properties.Settings.Default.Save();
+            catch (Exception generalException)
+            {
+                MessageBox.Show($"Error - {generalException.Message}");
+            }
+
             btnCancel.Text = "Close";
-            
+
         }//End Saving website
 
         private void PopulateSavedSettings()
         {
             //Displaying current settings
             txbWebsite.Text = Properties.Settings.Default.InstructureSite.ToString();
+
+            if (Properties.Settings.Default.InstructureSite != "" && Properties.Settings.Default.InstructureSite != "No URL saved")
+            {
+                lnkGetAccessTokenLink.Enabled = true;
+                lnkGetAccessTokenLink.Text = $"Generate access token";
+            }
+
             string currentAccessToken = Properties.Settings.Default.CurrentAccessToken;
             //Display new access Token with mask make sure the sting is long enough
             if (currentAccessToken.Length > 7)
             {
                 txbCurrentAccessToken.Text = (string.Concat(currentAccessToken.Substring(0, 7), "".PadRight(currentAccessToken.Length - 7, '*')));
             }
+
+
 
         }
 
@@ -152,6 +173,18 @@ namespace CanvasAPIApp
 
             }
             PopulateSavedSettings();
+        }
+
+        private void lnkGetAccessTokenLink_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                System.Diagnostics.Process.Start($"{Properties.Settings.Default.InstructureSite}/profile");
+            }
+            catch (Exception exc)
+            {
+                MessageBox.Show($"Error - {exc.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
This shouldn't conflict with the other merge at all, or it should only affect the Access Token settings form.

This mainly fixed a crash when invalid URL is first entered.

Also added a link to generate access token once a valid URL is set. It opens this link in the default browser.