### PR TITLE
Search crashes in courses form

### DIFF
--- a/DATCCanvasAPIApp/CoursesForm.cs
+++ b/DATCCanvasAPIApp/CoursesForm.cs
@@ -238,7 +238,10 @@ namespace CanvasAPIApp
                 foreach (DataGridViewRow row in courseStudentsGrid.Rows)
                 {
                     //mash name, ID and state together to search via substring
-                    string search = row.Cells["studentName"].Value.ToString() + row.Cells["studentID"].Value.ToString();
+                    string search = row.Cells["studentName"].Value.ToString();
+                    
+                    if(row.Cells["studentID"].Value != null)
+                        search += row.Cells["studentID"].Value.ToString();
 
                     if (!search.ToLower().Contains(enrolledStudentsSearch.Text.ToLower()))
                     {

--- a/DATCCanvasAPIApp/CoursesForm.cs
+++ b/DATCCanvasAPIApp/CoursesForm.cs
@@ -177,7 +177,6 @@ namespace CanvasAPIApp
             {
                 string roleEndPoint = Properties.Settings.Default.InstructureSite + "/api/v1/courses/" + courseId + "/?";//Get endpoint for role
                 var roleClient = new RestClient(roleEndPoint);
-                Console.Out.WriteLine(roleEndPoint);
                 var roleJson = roleClient.MakeRequest(coursesAccessToken);
                 dynamic roleJsonObj = JsonConvert.DeserializeObject(roleJson);
 
@@ -234,19 +233,25 @@ namespace CanvasAPIApp
 
         private void enrolledStudentsSearch_TextChanged(object sender, EventArgs e)
         {
-            foreach (DataGridViewRow row in courseStudentsGrid.Rows)
+            try
             {
-                //mash name, ID and state together to search via substring
-                string search = row.Cells["studentName"].Value.ToString() + row.Cells["studentID"].Value.ToString();
+                foreach (DataGridViewRow row in courseStudentsGrid.Rows)
+                {
+                    //mash name, ID and state together to search via substring
+                    string search = row.Cells["studentName"].Value.ToString() + row.Cells["studentID"].Value.ToString();
 
-                if (!search.ToLower().Contains(enrolledStudentsSearch.Text.ToLower()))
-                {
-                    row.Visible = false;
+                    if (!search.ToLower().Contains(enrolledStudentsSearch.Text.ToLower()))
+                    {
+                        row.Visible = false;
+                    }
+                    else if ((search.ToLower().Contains(enrolledStudentsSearch.Text.ToLower())))
+                    {
+                        row.Visible = true;
+                    }
                 }
-                else if ((search.ToLower().Contains(enrolledStudentsSearch.Text.ToLower())))
-                {
-                    row.Visible = true;
-                }
+            }catch(Exception exc)
+            {
+                MessageBox.Show("Error - " + exc.Message);
             }
         }
 


### PR DESCRIPTION
This was occasionally crashing in a specific bug. At the very least I caught the exception so it will throw an error rather than killing the entire application.

Something is causing the ID to not be displayed in the course students list, and this ended up throwing a null error when it tries to search through the ID column.