### PR TITLE
Grading queue: Reservation conflicts

### DIFF
--- a/DATCCanvasAPIApp/GradingQueue.Designer.cs
+++ b/DATCCanvasAPIApp/GradingQueue.Designer.cs
@@ -47,6 +47,7 @@
             this.courseFilterLbl = new System.Windows.Forms.Label();
             this.btnPrioritySettings = new System.Windows.Forms.Button();
             this.btnLoadCourses = new System.Windows.Forms.Button();
+            this.button1 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.gradingDataGrid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudSeconds)).BeginInit();
             this.SuspendLayout();
@@ -249,12 +250,14 @@
             this.btnLoadCourses.Text = "Refresh courses";
             this.btnLoadCourses.UseVisualStyleBackColor = false;
             this.btnLoadCourses.Click += new System.EventHandler(this.btnLoadCourses_Click);
+            
             // 
             // GradingQueue
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(844, 526);
+            this.Controls.Add(this.button1);
             this.Controls.Add(this.btnLoadCourses);
             this.Controls.Add(this.btnPrioritySettings);
             this.Controls.Add(this.courseFilterTxt);
@@ -295,5 +298,6 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn grades_url;
         private System.Windows.Forms.Button btnPrioritySettings;
         private System.Windows.Forms.Button btnLoadCourses;
+        private System.Windows.Forms.Button button1;
     }
 }

--- a/DATCCanvasAPIApp/GradingQueue.Designer.cs
+++ b/DATCCanvasAPIApp/GradingQueue.Designer.cs
@@ -47,7 +47,6 @@
             this.courseFilterLbl = new System.Windows.Forms.Label();
             this.btnPrioritySettings = new System.Windows.Forms.Button();
             this.btnLoadCourses = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.gradingDataGrid)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudSeconds)).BeginInit();
             this.SuspendLayout();
@@ -250,14 +249,12 @@
             this.btnLoadCourses.Text = "Refresh courses";
             this.btnLoadCourses.UseVisualStyleBackColor = false;
             this.btnLoadCourses.Click += new System.EventHandler(this.btnLoadCourses_Click);
-            
             // 
             // GradingQueue
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(844, 526);
-            this.Controls.Add(this.button1);
             this.Controls.Add(this.btnLoadCourses);
             this.Controls.Add(this.btnPrioritySettings);
             this.Controls.Add(this.courseFilterTxt);
@@ -298,6 +295,5 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn grades_url;
         private System.Windows.Forms.Button btnPrioritySettings;
         private System.Windows.Forms.Button btnLoadCourses;
-        private System.Windows.Forms.Button button1;
     }
 }

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -82,6 +82,15 @@ namespace CanvasAPIApp
             btnRefreshQueue.Enabled = false;
             lblMessageBox.Text = "Getting Courses";
 
+            //saves sorting for after refresh
+            var sortColumn = gradingDataGrid.SortedColumn;
+
+            System.ComponentModel.ListSortDirection sortDirection = new System.ComponentModel.ListSortDirection();
+            if (gradingDataGrid.SortOrder == SortOrder.Ascending)
+                sortDirection = System.ComponentModel.ListSortDirection.Ascending;
+            else if(gradingDataGrid.SortOrder == SortOrder.Descending)
+                sortDirection = System.ComponentModel.ListSortDirection.Descending;
+
             //gets courses if they aren't already set
             if (CourseList.Count == 0)
             {
@@ -116,6 +125,9 @@ namespace CanvasAPIApp
                     mongoCollection.DeleteOne(filter);
                 }
             }
+
+            //resets sort direction
+            gradingDataGrid.Sort(sortColumn, sortDirection);
 
             // using this method as hook to enable courseFilterTxt
             enableCourseFilter();

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -356,15 +356,20 @@ namespace CanvasAPIApp
                         //Reserved is checked
                         if (Convert.ToBoolean(gradingDataGrid.CurrentCell.Value) == true)
                         {
-                            gradingDataGrid.CurrentCell.Value = false;
-                            //Remove the data from the database
-                            if (connectedToMongoDB == true)
+                            DialogResult dialogResult = MessageBox.Show("This assignment is currently reserved. Do you want to unassign it?", "Unreserve?", MessageBoxButtons.YesNo);
+
+                            if (dialogResult == DialogResult.Yes)
                             {
-                                var mongoCollection = mongoDatabase.GetCollection<BsonDocument>(Properties.Settings.Default.MongoDBGradingCollection);
-                                string url = gradingDataGrid.Rows[e.RowIndex].Cells[6].EditedFormattedValue.ToString();
-                                //Make call for URL
-                                var filter = Builders<BsonDocument>.Filter.Eq("_id", url);
-                                mongoCollection.DeleteOne(filter);
+                                gradingDataGrid.CurrentCell.Value = false;
+                                //Remove the data from the database
+                                if (connectedToMongoDB == true)
+                                {
+                                    var mongoCollection = mongoDatabase.GetCollection<BsonDocument>(Properties.Settings.Default.MongoDBGradingCollection);
+                                    string url = gradingDataGrid.Rows[e.RowIndex].Cells[6].EditedFormattedValue.ToString();
+                                    //Make call for URL
+                                    var filter = Builders<BsonDocument>.Filter.Eq("_id", url);
+                                    mongoCollection.DeleteOne(filter);
+                                }
                             }
                         }
                         else //Reserved is not checked

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -374,11 +374,8 @@ namespace CanvasAPIApp
                         }
                         else //Reserved is not checked
                         {
-                            gradingDataGrid.CurrentCell.Value = true;
-
+                            
                             string url = gradingDataGrid.Rows[e.RowIndex].Cells[6].EditedFormattedValue.ToString();
-
-                            Process browserTab = Process.Start(url); //grading url in new tab
 
                             //Add the data to the database
                             if (connectedToMongoDB == true)
@@ -389,6 +386,13 @@ namespace CanvasAPIApp
                                 try
                                 {
                                     mongoCollection.InsertOne(documentToWrite); //try to write to database
+
+                                    //continue if successful:
+                                    gradingDataGrid.CurrentCell.Value = true;
+
+                                    Process browserTab = Process.Start(url); //grading url in new tab
+
+
                                 }
                                 catch (MongoDB.Driver.MongoWriteException writeException)
                                 {
@@ -398,8 +402,6 @@ namespace CanvasAPIApp
                                         var filter = Builders<BsonDocument>.Filter.Eq("_id", url);
                                         var conflictDocument = mongoCollection.Find(filter).FirstOrDefault();
                                         var grader = conflictDocument.GetElement("grader");
-
-                                        browserTab.Kill(); //closes the grading tab
 
                                         this.Activate(); //pulls the form into focus to display message
                                         MessageBox.Show($"This assignment was reserved by {grader.Value}");
@@ -412,7 +414,7 @@ namespace CanvasAPIApp
                                         MessageBox.Show($"There was a MongoDB write error {writeException.Message}");
                                     }
                                 }
-                            }
+                            }//end if(connectedToMongo)
                         }
                     }
 

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -394,6 +394,9 @@ namespace CanvasAPIApp
                                         var filter = Builders<BsonDocument>.Filter.Eq("_id", url);
                                         var conflictDocument = mongoCollection.Find(filter).FirstOrDefault();
                                         var grader = conflictDocument.GetElement("grader");
+                                        
+                                        this.Activate(); //pulls the form into focus
+
                                         MessageBox.Show($"This assignment was reserved by {grader.Value}");
                                     }
                                     else
@@ -542,6 +545,6 @@ namespace CanvasAPIApp
             }
         }
 
-
+        
     }
 }

--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -25,7 +25,6 @@ namespace CanvasAPIApp
         public static PrioritySettings prioritySettings = new PrioritySettings();
         public static int defaultPriority { get; set; }
 
-
         private bool mongoWarningshown = false;
 
         public GradingQueue()
@@ -66,7 +65,6 @@ namespace CanvasAPIApp
         {
             prioritySettings = new PrioritySettings();
             defaultPriority = Properties.Settings.Default.DefaultPriority;
-
 
         }
 
@@ -385,18 +383,18 @@ namespace CanvasAPIApp
                                 BsonDocument documentToWrite = new BsonDocument { { "_id", url }, { "grader", Properties.Settings.Default.AppUserName }, { "reserved_at", DateTime.Now.ToString() } };
                                 try
                                 {
-                                    mongoCollection.InsertOne(documentToWrite);
+                                    mongoCollection.InsertOne(documentToWrite); //try to write to database
                                 }
                                 catch (MongoDB.Driver.MongoWriteException writeException)
                                 {
                                     //Make call for URL
-                                    if (writeException.WriteError.Category == ServerErrorCategory.DuplicateKey) // if entry has already been made
+                                    if (writeException.WriteError.Category == ServerErrorCategory.DuplicateKey) // if this entry has already been made (assignment already reserved)
                                     {
                                         var filter = Builders<BsonDocument>.Filter.Eq("_id", url);
                                         var conflictDocument = mongoCollection.Find(filter).FirstOrDefault();
                                         var grader = conflictDocument.GetElement("grader");
 
-                                        browserTab.Kill(); //closes grading tab
+                                        browserTab.Kill(); //closes the grading tab
 
                                         this.Activate(); //pulls the form into focus to display message
                                         MessageBox.Show($"This assignment was reserved by {grader.Value}");

--- a/DATCCanvasAPIApp/GradingQueue.resx
+++ b/DATCCanvasAPIApp/GradingQueue.resx
@@ -141,30 +141,6 @@
   <metadata name="grades_url.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="reserved.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Priority.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="CourseNumber.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="AssignmentNameColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Submit_at.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Workflow_state.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Speedgrader_url.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="grades_url.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="timerRefreshQueue.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>


### PR DESCRIPTION
I'm not sure that this is how we want it exactly, but it's a start.

It will now bring the app into focus before displaying the "already reserved" message, and simply close the grading tab we just opened. It will also force the queue to refresh to update the status of the checkbox that caused the conflict. You should be able to see whats going on easily just by the diff.

I was able to connect Mongo last night but I'm having issues with it on a different computer today, so I haven't tested these all together, I have figure out what's going on there.