### PR TITLE
I had 3 things written down here that we discussed:

### DIFF
--- a/DATCCanvasAPIApp/GradingQueue.cs
+++ b/DATCCanvasAPIApp/GradingQueue.cs
@@ -321,7 +321,7 @@ namespace CanvasAPIApp
             await RefreshQueue();
         }
 
-        private void gradingDataGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
+        private async void gradingDataGrid_CellContentClick(object sender, DataGridViewCellEventArgs e)
         {
             if (gradingDataGrid.CurrentCell != null)
             {
@@ -374,7 +374,8 @@ namespace CanvasAPIApp
                             gradingDataGrid.CurrentCell.Value = true;
 
                             string url = gradingDataGrid.Rows[e.RowIndex].Cells[6].EditedFormattedValue.ToString();
-                            Process.Start(url);
+                            
+                            Process browserTab = Process.Start(url); //browser tab process
 
                             //Add the data to the database
                             if (connectedToMongoDB == true)
@@ -394,7 +395,14 @@ namespace CanvasAPIApp
                                         var filter = Builders<BsonDocument>.Filter.Eq("_id", url);
                                         var conflictDocument = mongoCollection.Find(filter).FirstOrDefault();
                                         var grader = conflictDocument.GetElement("grader");
+
+                                        this.Activate(); //brings form into focus
+
+                                        browserTab.Kill(); //closes browser tab
+
                                         MessageBox.Show($"This assignment was reserved by {grader.Value}");
+
+                                        await RefreshQueue(); //to update checkbox
                                     }
                                     else
                                     {


### PR DESCRIPTION
1 - Crashing when checking auto refresh before loading - (I wasn't able to reproduce this)
2 - Like we discussed it will now open the grading URL in the browser before checking reservation status. If the assignment happens  to be reserved, it will close the tab and bring the app into focus. This probably happens quickly and pretty seemlessly.
3 - After reservation failure, refresh the queue to update the status of the checkbox